### PR TITLE
Make WebsocketServer's internal ydoc mandatory

### DIFF
--- a/ypy_websocket/websocket_provider.py
+++ b/ypy_websocket/websocket_provider.py
@@ -8,7 +8,6 @@ class WebsocketProvider:
     _ydoc: YDoc
 
     def __init__(self, ydoc: YDoc, websocket):
-        ydoc.initialized.set()
         self._ydoc = ydoc
         self._websocket = websocket
         asyncio.create_task(self._run())

--- a/ypy_websocket/ydoc.py
+++ b/ypy_websocket/ydoc.py
@@ -22,6 +22,7 @@ class YDoc(Y.YDoc):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.initialized = asyncio.Event()
+        self.initialized.set()
         self.synced = asyncio.Event()
         self._update_queue = asyncio.Queue()
 


### PR DESCRIPTION
A `WebsocketServer` *must* have an internal ydoc, in order to sync new clients.